### PR TITLE
Isa tests

### DIFF
--- a/src/components/EditForm.isa.test.jsx
+++ b/src/components/EditForm.isa.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import EditForm from "../components/EditForm";
+
+vi.mock("../utilities/firebase", () => ({
+  auth: {
+    currentUser: { uid: "testUserId" },
+  },
+}));
+
+vi.mock("../components/WarmthLevelInfo", () => ({
+  default: () => <div data-testid="warmth-info-mock" />,
+}));
+
+describe("EditForm Warmth Level Visibility", () => {
+  it("should hide the warmth level input when a category with a parent category of 'Footwear' is selected", () => {
+    const mockCategories = ["Sneakers", "T-Shirt"];
+    const mockCategoriesDict = {
+      Sneakers: "Footwear",
+      "T-Shirt": "Top",
+    };
+    const setShowModal = vi.fn();
+
+    render(
+      <EditForm
+        showModal={true}
+        setShowModal={setShowModal}
+        categories={mockCategories}
+        categoriesDict={mockCategoriesDict}
+        editing={false}
+      />
+    );
+
+    expect(screen.getByText(/Add Clothes/i)).toBeInTheDocument();
+
+    // click on category dropdown
+    const categoryDropdownButton = screen.getByRole("button", {
+      name: /Category/i,
+    });
+    fireEvent.click(categoryDropdownButton);
+
+    const dropdownOptions = screen.getByRole("listbox");
+
+    // select sneakers within dropdown
+    const sneakersOption = within(dropdownOptions).getByText("Sneakers");
+    fireEvent.click(sneakersOption);
+
+    // check warmth level isn't there
+    const warmthLevelInput = screen.queryByLabelText(/Warmth Level/i);
+    expect(warmthLevelInput).toBeNull();
+  });
+});

--- a/src/components/WarmthLevelInfo.isa.test.jsx
+++ b/src/components/WarmthLevelInfo.isa.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import EditForm from "../components/EditForm";
+
+vi.mock("../utilities/firebase", () => ({
+  auth: {
+    currentUser: { uid: "testUserId" },
+  },
+}));
+
+vi.mock("../components/WarmthLevelInfo", () => ({
+  default: ({ isVisible }) =>
+    isVisible ? (
+      <div data-testid="warmth-info-tooltip">Warmth Level Information</div>
+    ) : null,
+}));
+
+describe("EditForm Warmth Level Tooltip", () => {
+  it("should display the warmth level tooltip when the info button is clicked", () => {
+    const mockCategories = ["T-Shirt", "Sweater"];
+    const mockCategoriesDict = {
+      "T-Shirt": "Top",
+      Sweater: "Top",
+    };
+    const setShowModal = vi.fn();
+
+    render(
+      <EditForm
+        showModal={true}
+        setShowModal={setShowModal}
+        categories={mockCategories}
+        categoriesDict={mockCategoriesDict}
+        editing={false}
+      />
+    );
+
+    expect(screen.getByText(/Add Clothes/i)).toBeInTheDocument();
+
+    const infoButtons = screen.queryAllByRole("button");
+    const warmthInfoButton = infoButtons.find((button) =>
+      within(button).queryByText(/info/i)
+    );
+    expect(warmthInfoButton).toBeDefined();
+
+    fireEvent.click(warmthInfoButton);
+
+    const tooltip = screen.getByTestId("warmth-info-tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent("Warmth Level Information");
+  });
+});


### PR DESCRIPTION
- Given the category chosen is footwear when adding new clothes, the warmth level is not asked for
- When a user clicks on the info button next to the warmth level, it displays a tooltip with information explaining what "warmth level" means